### PR TITLE
[issue] 1초봉 캔들 데이터에 timestamp 필드 누락 #8

### DIFF
--- a/src/api_client.py
+++ b/src/api_client.py
@@ -117,6 +117,7 @@ class UpbitTickerWS:
             "trade_price" : data["trade_price"], #종가
             "candle_acc_trade_volume" : data["candle_acc_trade_volume"], #분 거래량
             "candle_acc_trade_price" : data["candle_acc_trade_price"], #분 거래대금
+            "timestamp": int(data["timestamp"])
         }
 
         self.handle_candle_1s(candle)
@@ -165,6 +166,11 @@ class UpbitTickerWS:
         - 로그 저장
         - Spark Streaming 입력 등으로 확장 가능
         """
+        event_dt = datetime.fromtimestamp(
+            data["timestamp"] / 1000, tz=timezone.utc
+        )
+
+        minute_dt = event_dt.replace(second=0, microsecond=0)
         candle_message = {
             "exchange": "upbit",
             "type": data["type"],
@@ -176,6 +182,7 @@ class UpbitTickerWS:
             "trade_price": data["trade_price"],
             "candle_acc_trade_volume": data["candle_acc_trade_volume"],
             "candle_acc_trade_price": data["candle_acc_trade_price"],
+            "timestamp": int(data["timestamp"])
         }
 
         self.producer.send(


### PR DESCRIPTION
## 이슈 설명
Upbit WebSocket `candle.1s` 스트림에서 수신되는 1초봉 캔들 데이터를 Kafka로 전송하는 과정에서  
이벤트 시각을 나타내는 `timestamp` 필드가 누락되어 있음.

현재 ticker 데이터는 이벤트 타임(`timestamp`) 기준으로 처리되고 있으나,  
1초봉 캔들 데이터에는 동일한 기준 시간이 없어 downstream 처리(Spark, 집계, 윈도우 처리)에 제약이 발생함.

## 작업내용
- 1초봉 캔들 데이터에 `timestamp` 필드 추가