### PR TITLE
체크포인트 디렉토리 권한 문제로 인한 팀원 환경 간 삭제 불가 #17

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -11,7 +11,8 @@ services:
     hostname: spark-master
     command: /opt/spark/bin/spark-class org.apache.spark.deploy.master.Master
     volumes:
-      - ../data:/data
+      - ../data/silver:/data/silver
+      - spark_checkpoint:/data/checkpoint
     ports:
       - "7077:7077"   # Spark Master
       - "8081:8080"   # Spark Master UI
@@ -31,7 +32,8 @@ services:
       org.apache.spark.deploy.worker.Worker
       spark://spark-master:7077
     volumes:
-      - ../data:/data
+      - ../data:/silver:/data/silver
+      - spark_checkpoint:/data/checkpoint
     environment:
       SPARK_WORKER_MEMORY: 2g
       SPARK_WORKER_CORES: 2
@@ -54,7 +56,8 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
     volumes:
       - ../src:/app/src
-      - ../data:/data
+      - ../data/silver:/data/silver
+      - spark_checkpoint:/data/checkpoint
       - ../output:/output
     depends_on:
       kafka:
@@ -155,6 +158,7 @@ services:
 
 volumes:
   kafka-data:
+  spark_checkpoint:
 
 # ============================================
 # 네트워크 정의 (Phase 4 Spark 연동 대비)


### PR DESCRIPTION
문제 상황
Spark Structured Streaming 실행 시 /data/checkpoint 하위 디렉토리가 생성되는데, 해당 디렉토리가 컨테이너 내부 사용자(root) 권한으로 생성되어 호스트 파일 시스템에 root 소유 파일로 남는 문제가 발생함. 이로 인해 일부 팀원은 체크포인트 디렉토리를 정상적으로 삭제할 수 없고 sudo 권한이 있는 환경에서는 삭제가 가능하지만, sudo 권한이 없거나 제한된 환경에서는 디렉토리 삭제가 불가능한 상황 발생

원인
Spark 컨테이너에서 ../data:/data 형태로 호스트 디렉토리를 직접 마운트한 상태에서 체크포인트 디렉토리를 /data/checkpoint 경로에 생성
컨테이너 실행 사용자와 호스트 사용자 간 UID/GID 불일치로 인해 권한 충돌 발생

영향
팀원 간 개발 환경(WSL / 로컬 Linux / 권한 설정)에 따라 동작이 달라짐
체크포인트 초기화가 필요한 경우 개발 진행이 막힘
반복적인 sudo rm -rf 필요로 개발 경험 저하

해결 방향
Spark 체크포인트 디렉토리를 Docker named volume으로 분리
호스트 파일 시스템에는 결과 데이터(silver/output)만 마운트하여 공유
컨테이너 내부 상태 데이터는 Docker가 관리하도록 구조 개선

본 이슈는 Spark/Kafka 로직 문제가 아니라 Docker volume 마운트 및 파일 권한 설계 이슈에 해당함.